### PR TITLE
Update README.md: add a event video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Review our [Contributing Instructions](CONTRIBUTING.md) before beginning editing
 | 67 | 2022-10-18 | Alex de Siqueira | [An Overview of 3D Image Processing Using scikit-image](2022/67-alex-image.md) | [v67_scikit-image](https://youtu.be/tPNUX5NxlVY) 
 | 68 | 2022-10-25 | Marianne Corvellec | [A Bioimage Data Analysis Workflow with scikit-image](2022/68-marianne-bioimage.md) | [v68_bioimage](https://youtu.be/NqdhuU1fX5A) 
 | 69 | 2022-11-15 | Bruno Rocha | [Introduction to Rust Programming](2022/69-bruno-rust.md) | [v69_rust](https://youtu.be/7E8nLExn3WI) 
-| 70 | 2022-11-29 | Oriol Abril Pla | [Contributing to ArviZ and Open Source: Social and Technical Sides](2022/70-oriol-arviz.md) |
+| 70 | 2022-11-29 | Oriol Abril Pla | [Contributing to ArviZ and Open Source: Social and Technical Sides](2022/70-oriol-arviz.md) |[v70_Arviz_OS_contributions](https://youtu.be/457ZTes4xOI)
 | 71 | 2022-12-06 | Wendy Grus & Stacey Williams | [Land First Data Science Job](2022/71-wg-sw-career.md) |
 |    | 2023          |      |    |     |        |
 | 72 | 2023-01-10 | Marco Gorelli | [How You (yes, you!) Can Contribute to Pandas](2023/72-marco-pandas.md) |

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Review our [Contributing Instructions](CONTRIBUTING.md) before beginning editing
 | 67 | 2022-10-18 | Alex de Siqueira | [An Overview of 3D Image Processing Using scikit-image](2022/67-alex-image.md) | [v67_scikit-image](https://youtu.be/tPNUX5NxlVY) 
 | 68 | 2022-10-25 | Marianne Corvellec | [A Bioimage Data Analysis Workflow with scikit-image](2022/68-marianne-bioimage.md) | [v68_bioimage](https://youtu.be/NqdhuU1fX5A) 
 | 69 | 2022-11-15 | Bruno Rocha | [Introduction to Rust Programming](2022/69-bruno-rust.md) | [v69_rust](https://youtu.be/7E8nLExn3WI) 
-| 70 | 2022-11-29 | Oriol Abril Pla | [Contributing to ArviZ and Open Source: Social and Technical Sides](2022/70-oriol-arviz.md) |[v70_Arviz_OS_contributions](https://youtu.be/457ZTes4xOI)
+| 70 | 2022-11-29 | Oriol Abril Pla | [Contributing to ArviZ and Open Source: Social and Technical Sides](2022/70-oriol-arviz.md) | [v70_Arviz_OS_contributions](https://youtu.be/457ZTes4xOI)
 | 71 | 2022-12-06 | Wendy Grus & Stacey Williams | [Land First Data Science Job](2022/71-wg-sw-career.md) |
 |    | 2023          |      |    |     |        |
 | 72 | 2023-01-10 | Marco Gorelli | [How You (yes, you!) Can Contribute to Pandas](2023/72-marco-pandas.md) |


### PR DESCRIPTION
#### Type of contribution
- [x] Transcripts

#### Reference: Issue or Pull Request (PR)
- [x] Towards #151   [this will keep reference issue or PR open]  <=== _When in doubt, pick this one._

#### Description: What does this implement/fix? Explain your changes.

I added a video link for the meetup event 70 in README.md.

#### Checklist

- [x] Did you review the [CONTRIBUTING GUIDE](https://github.com/data-umbrella/data-umbrella-website/blob/main/CONTRIBUTING.md)
- [x] Did you reference an issue or another pull request?

#### Any other comments?

I could not find the old meetup events date.
Is there the way to find the old meetup events date?
Especially, I want to know a date of number 5.
