### PR TITLE
Add Information security and Debugging in python event transcript files

### DIFF
--- a/2023/88-zoe-information-security.md
+++ b/2023/88-zoe-information-security.md
@@ -24,7 +24,8 @@ This talk will define what information security is, explain why it is important 
 https://github.com/data-umbrella/event-transcripts/issues/92
 
 ## About the Speaker
-Zoe Braiterman
+Zoe Braiterman is an information security consultant and researcher.
+
 - GitHub:  https://github.com/zbraiterman
 - LinkedIn: https://www.linkedin.com/in/zoebraiterman/
 

--- a/2023/88-zoe-information-security.md
+++ b/2023/88-zoe-information-security.md
@@ -1,0 +1,40 @@
+# Zoe Braiterman:  An Overview of Information Security
+
+## Upcoming Events
+Join our Meetup group for more events!
+https://www.meetup.com/data-umbrella
+
+## Key Links
+- Transcript: https://github.com/data-umbrella/event-transcripts/blob/main/2023/88-zoe-information-security.md
+- Meetup Event: https://www.meetup.com/data-umbrella/events/295529129/
+- Video:  
+- GitHub repo:  
+- Transcriber:  ? [needs a transcriber]
+
+## Resources
+None
+
+## About the Event
+This talk will define what information security is, explain why it is important and provide an overview of the information security career landscape.
+
+```
+## Timestamps
+00:00 Help us add timestamps
+```
+https://github.com/data-umbrella/event-transcripts/issues/92
+
+## About the Speaker
+Zoe Braiterman
+- GitHub:  https://github.com/zbraiterman
+- LinkedIn: https://www.linkedin.com/in/zoebraiterman/
+
+#ComputerSecurity #DataManagement
+
+## Video
+<a href="" target="_blank"><img src=""
+alt="An Overview of Information Security" width="50%" /></a>
+
+## Timestamps
+[get from video]
+
+## Transcript

--- a/2023/89-juan-python-debugging.md
+++ b/2023/89-juan-python-debugging.md
@@ -1,0 +1,43 @@
+# Juan Luis Cano Rodríguez:  Into the rabbit hole: Debugging in Python
+
+## Upcoming Events
+Join our Meetup group for more events!
+https://www.meetup.com/data-umbrella
+
+## Key Links
+- Transcript: https://github.com/data-umbrella/event-transcripts/blob/main/2023/89-juan-python-debugging.md
+- Meetup Event: https://www.meetup.com/data-umbrella/events/295529919/
+- Video:  
+- GitHub repo:  
+- Transcriber:  ? [needs a transcriber]
+
+## Resources
+- https://github.com/astrojuanlu/workshop-debugging-python
+
+
+## About the Event
+Your code gives an error. Or worse: it doesn't give an error, but doesn't do what you want. Welcome to the hard part of programming! What to do now?
+
+In this talk we will talk about debugging, which includes a broad set of techniques to identify the root causes of undesired behavior in programs and eventually fix them. We will start with a theoretical introduction of the different types of debugging, we will describe a couple of techniques that you can use, and we will apply them in practice, both in Jupyter Notebook (using its new interactive debugger) and in VSCode.
+```
+## Timestamps
+00:00 Help us add timestamps
+```
+https://github.com/data-umbrella/event-transcripts/issues/92
+
+## About the Speaker
+Juan Luis (he/him/él) works as Developer Advocate at QuantumBlack, AI by McKinsey, with a focus on Kedro, an open source data science framework. He has a decade of experience as developer advocate, software engineer, and Python trainer in several industries. PSF Fellow since 2017, he has made significant contributions to the PyData stack, published several open-source packages, and organized the first seven PyCons in Spain. Currently he is the lead organizer of the PyData Madrid monthly meetups.
+
+- LinkedIn: https://www.linkedin.com/in/juanluiscanor/
+- GitHub:  https://github.com/astrojuanlu/
+
+#python #codereview
+
+## Video
+<a href="" target="_blank"><img src=""
+alt="Into the rabbit hole: Debugging in Python" width="50%" /></a>
+
+## Timestamps
+[get from video]
+
+## Transcript


### PR DESCRIPTION
#### Type of contribution
- [ ] Timestamps
- [x] Transcripts
- [ ] Other


#### Description: What does this implement/fix? Explain your changes.



#### Checklist

- [x] Did you review the [CONTRIBUTING GUIDE](https://github.com/data-umbrella/data-umbrella-website/blob/main/CONTRIBUTING.md)
- [ ] Did you reference an issue or another pull request?

#### Any other comments?
For now the resource section is None in case of information security webinar. Will update it post event if there are any resources. Also, removed pre-existing links in youtube embed.

<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.

Thanks for contributing!
-->
